### PR TITLE
Fix spelling of μŠup in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ We decided to create our own replaced board what will be compatible with the ori
 The LASKAKIT ESP-VINDRIKTNING as well as Ikea Vindriktning includes USB-C connector. The orginal board is using the USB-C just for power supply, the ESP-VINDRIKTNING is using USB-C for power and also for programming, because the board includes built-in USB-UART IC as programmer. 
 
 ## Connectors
-The LASKAKIT ESP-VINDRIKTNING contains six connectors. Two of them are used for original dust sensor - sensor and fan. The third connector is called uŠup and it is compatible with STEMMA QT and Qwiic JST-SH. Thanks to this connector, you can add [temperature/humidity sensor SHT40](https://www.laskakit.cz/laskakit-sht40-senzor-teploty-a-vlhkosti-vzduchu/) or [SCD41 (sensor of CO2/temperature/humidity)](https://www.laskakit.cz/laskakit-scd41-senzor-co2--teploty-a-vlhkosti-vzduchu/) and improve the measurement of air. 
+The LASKAKIT ESP-VINDRIKTNING contains six connectors. Two of them are used for original dust sensor - sensor and fan. The third connector is called μŠup and it is compatible with STEMMA QT and Qwiic JST-SH. Thanks to this connector, you can add [temperature/humidity sensor SHT40](https://www.laskakit.cz/laskakit-sht40-senzor-teploty-a-vlhkosti-vzduchu/) or [SCD41 (sensor of CO2/temperature/humidity)](https://www.laskakit.cz/laskakit-scd41-senzor-co2--teploty-a-vlhkosti-vzduchu/) and improve the measurement of air. 
 Fourth connector is just 4pin header and you can solder what you want. The 4pin connector includes I2C and power supply with 3.3V. 
 The reset of the connectors contains power supply (3.3V) and GPIO which you can use for your purpose. Also the hardware SPI may be used from this connector. 
 

--- a/README_CZ.md
+++ b/README_CZ.md
@@ -12,7 +12,7 @@ LASKAKIT ESP-VINDRIKTNING stejně jako originální Ikea Vindriktning obsahuje U
 Stačí jí tedy připojit do USB konektoru a otevřít třeba Arduino IDE. 
 
 ## Konektory
-LASKAKIT ESP-VINDRIKTNING obsahuje celkem šest konektorů. První dva slouží k připojení originální čidla - čidla prašnosti (čidlo a ventilátor). Třetí [konektor je uŠup](https://blog.laskarduino.cz/predstavujeme-univerzalni-konektor-pro-propojeni-modulu-a-cidel-%ce%bcsup/),
+LASKAKIT ESP-VINDRIKTNING obsahuje celkem šest konektorů. První dva slouží k připojení originální čidla - čidla prašnosti (čidlo a ventilátor). Třetí [konektor je μŠup](https://blog.laskarduino.cz/predstavujeme-univerzalni-konektor-pro-propojeni-modulu-a-cidel-%ce%bcsup/),
 který je kompatibilní s STEMMA QT a Qwiic JST-SH
 Díky tomuto konektoru můžeš přidat čidlo [tepoty/vlhkosti SHT40](https://www.laskakit.cz/laskakit-sht40-senzor-teploty-a-vlhkosti-vzduchu/) nebo [SCD41 (čidlo CO2/teploty/vlhkosti)](https://www.laskakit.cz/laskakit-scd41-senzor-co2--teploty-a-vlhkosti-vzduchu/) 
 a vytvořit tak komplexní měření kvality vzduchu.


### PR DESCRIPTION
Just a small typo fix in the README